### PR TITLE
[FIX] Correct array in parameter

### DIFF
--- a/SNK/SNK/View/Screens/CharactersScreens/CharactersListView.swift
+++ b/SNK/SNK/View/Screens/CharactersScreens/CharactersListView.swift
@@ -40,7 +40,7 @@ struct CharactersListView: View {
                         LazyVStack {
                             ForEach(self.characters, id: \.self) { item in
                                 NavigationLink {
-                                    CharacterDetailView(character: item, characters: self.characters, episodes: self.episodes)
+                                    CharacterDetailView(character: item, characters: self.originalCharacters, episodes: self.episodes)
                                 } label: {
                                     VStack {
                                         HStack {

--- a/SNK/SNK/View/Screens/EpisodesScreens/EpisodesListView.swift
+++ b/SNK/SNK/View/Screens/EpisodesScreens/EpisodesListView.swift
@@ -40,7 +40,7 @@ struct EpisodesListView: View {
                         LazyVStack {
                             ForEach(self.episodes.sorted { $0.episode ?? "" < $1.episode ?? "" }, id: \.self) { item in
                                 NavigationLink {
-                                    EpisodeDetailView(episode: item, episodes: self.episodes, characters: self.characters)
+                                    EpisodeDetailView(episode: item, episodes: self.originalEpisodes, characters: self.characters)
                                 } label: {
                                     VStack {
                                         HStack {


### PR DESCRIPTION
# Description

When it filters and choose a character and tap an episode later, the characters list inside that episode returned only the caracters filtered. I change the array what was in parameter to the correct array.